### PR TITLE
PR for reproducing SITES-18690

### DIFF
--- a/cf-editor-form-field-customization-sample/src/aem-cf-editor-1/web-src/src/components/CustomizedField.js
+++ b/cf-editor-form-field-customization-sample/src/aem-cf-editor-1/web-src/src/components/CustomizedField.js
@@ -47,7 +47,7 @@ const CustomizedField = () => {
       const height = Number((document.body.clientHeight).toFixed(0)) + 30; // we add extra 10px
       if (heightRef.current !== height) {
         heightRef.current = height;
-        // await wait(1); // we need to wait for some time to ensure that setHeight() is available for use
+        // await wait(2); // we need to wait for some time to ensure that setHeight() is available for use
         await guestConnection.host.field.setHeight(height);
       }
     }

--- a/cf-editor-form-field-customization-sample/src/aem-cf-editor-1/web-src/src/components/CustomizedField.js
+++ b/cf-editor-form-field-customization-sample/src/aem-cf-editor-1/web-src/src/components/CustomizedField.js
@@ -47,7 +47,7 @@ const CustomizedField = () => {
       const height = Number((document.body.clientHeight).toFixed(0)) + 30; // we add extra 10px
       if (heightRef.current !== height) {
         heightRef.current = height;
-        await wait(1); // we need to wait for some time to ensure that setHeight() is available for use
+        // await wait(1); // we need to wait for some time to ensure that setHeight() is available for use
         await guestConnection.host.field.setHeight(height);
       }
     }

--- a/cf-editor-form-field-customization-sample/src/aem-cf-editor-1/web-src/src/components/CustomizedField.js
+++ b/cf-editor-form-field-customization-sample/src/aem-cf-editor-1/web-src/src/components/CustomizedField.js
@@ -44,7 +44,7 @@ const CustomizedField = () => {
   const heightRef = useRef(0);
   const containerRef = useCallback(async (node) => {
     if (node !== null && guestConnection !== null) {
-      const height = Number((document.body.clientHeight).toFixed(0)) + 10; // we add extra 10px
+      const height = Number((document.body.clientHeight).toFixed(0)) + 30; // we add extra 10px
       if (heightRef.current !== height) {
         heightRef.current = height;
         await wait(1); // we need to wait for some time to ensure that setHeight() is available for use
@@ -96,6 +96,7 @@ const CustomizedField = () => {
       {fieldData.ready &&
         <View
           ref={containerRef}
+          marginBottom="size-225"
         >
           <TextField
             value={value}


### PR DESCRIPTION
These changes are intended to reproduce [SITES-18690](https://jira.corp.adobe.com/browse/SITES-18690). Should work on simple-text fields.
To see an issue you can open `ext=https://343284-sites18677-stage.adobeio-static.net/index.html`
- [author-p7452-e12437](https://experience.adobe.com/?repo=author-p7452-e12437.adobeaemcloud.com&ext=https://343284-sites18677-stage.adobeio-static.net/index.html#/@sitesinternal/aem/cf/editor/editor/content/dam/aditi-cf-tests/folder-a/en_us/adventures/surfing-in-hawaii)
- [author-p18453-e47228](https://experience.adobe.com/?repo=author-p18453-e47228.adobeaemcloud.com&ext=https://343284-sites18677-stage.adobeio-static.net/index.html#/@devxaccelerationprod/aem/cf/editor/editor/content%2Fdam%2Fheadless%2Fhs%2Ffinal-migration%2Farticles%2Femail%2Fcomparing-business-email-lite-and-microsoft-office-365%2Fcomparing-business-email-lite-and-microsoft-office-365?appId=aem-cf-editor) - ensure it is not in hibernation

With
```
await wait(1); // we need to wait for some time to ensure that setHeight() is available for use
```
enabled, you can use `ext=https://343284-sites18677.adobeio-static.net/index.html` to verify that it works:
- [author-p7452-e12437](https://experience.adobe.com/?repo=author-p7452-e12437.adobeaemcloud.com&ext=https://343284-sites18677.adobeio-static.net/index.html#/@sitesinternal/aem/cf/editor/editor/content/dam/aditi-cf-tests/folder-a/en_us/adventures/surfing-in-hawaii)
- [author-p18453-e47228](https://experience.adobe.com/?repo=author-p18453-e47228.adobeaemcloud.com&ext=https://343284-sites18677.adobeio-static.net/index.html#/@devxaccelerationprod/aem/cf/editor/editor/content%2Fdam%2Fheadless%2Fhs%2Ffinal-migration%2Farticles%2Femail%2Fcomparing-business-email-lite-and-microsoft-office-365%2Fcomparing-business-email-lite-and-microsoft-office-365?appId=aem-cf-editor)

Developer Console Project: https://developer.adobe.com/console/projects/343284/4566206088345123141/overview

CC: @VladimirZaets 
